### PR TITLE
Check that configuration exists before trying to access it.

### DIFF
--- a/src/main/groovy/fi/jasoft/plugin/TaskListener.groovy
+++ b/src/main/groovy/fi/jasoft/plugin/TaskListener.groovy
@@ -105,8 +105,12 @@ public class TaskListener implements TaskExecutionListener {
 
         if (task.getName() == 'javadoc'){
             task.source = Util.getMainSourceSet(project)
-            task.classpath += project.configurations[Configuration.JAVADOC.caption()];
-            task.classpath += project.configurations[Configuration.SERVER.caption()];
+            if (project.configurations.findByName(Configuration.JAVADOC.caption()) != null) {
+                task.classpath += project.configurations[Configuration.JAVADOC.caption()]
+            }
+            if (project.configurations.findByName(Configuration.SERVER.caption()) != null) {
+                task.classpath += project.configurations[Configuration.SERVER.caption()]
+            }
             task.failOnError = false
             task.options.addStringOption("sourcepath", "")
         }


### PR DESCRIPTION
This fixes #99 by checking that a configuration exists before trying to access it.
