### PR TITLE
fixed incompatibility with gradle 2.0

### DIFF
--- a/src/main/groovy/fi/jasoft/plugin/DependencyListener.groovy
+++ b/src/main/groovy/fi/jasoft/plugin/DependencyListener.groovy
@@ -113,7 +113,7 @@ class DependencyListener implements ProjectEvaluationListener {
         // Add repositories
         Repositories.values().each { repository ->
             if (repositories.findByName(repository.caption()) == null) {
-                if(gradleMinorVersion < 9){
+                if(gradleMinorVersion < 9 && gradleMajorVersion == 1){
                     repositories.mavenRepo(
                             name: repository.caption(),
                             url: repository.url()

--- a/vaadin.plugin
+++ b/vaadin.plugin
@@ -15,7 +15,7 @@ buildscript {
         def repositoryName = 'Jasoft.fi Maven Repository'
         def repositoryUrl = 'http://mvn.jasoft.fi/maven2'
 
-        if(gradleMinorVersion < 9){
+        if(gradleMinorVersion < 9 && gradleMajorVersion == 1){
             mavenRepo(
                 name: repositoryName,
                 url: repositoryUrl


### PR DESCRIPTION
just improved the check for minorVersion < 9 that switches between maven() and mavenRepo() calls.

previous version only checked for gradleMinorVersion < 9 which is true for gradle 2.0.
