### PR TITLE
Fix syntax for appending elements to a collection

### DIFF
--- a/src/main/groovy/fi/jasoft/plugin/DependencyListener.groovy
+++ b/src/main/groovy/fi/jasoft/plugin/DependencyListener.groovy
@@ -163,14 +163,14 @@ class DependencyListener implements ProjectEvaluationListener {
             def sources = project.sourceSets.main
             def testSources = project.sourceSets.test
 
-            sources.compileClasspath += project.configurations[serverConf]
-            testSources.compileClasspath += project.configurations[serverConf]
-            testSources.runtimeClasspath += project.configurations[serverConf]
+            sources.compileClasspath += [project.configurations[serverConf]]
+            testSources.compileClasspath += [project.configurations[serverConf]]
+            testSources.runtimeClasspath += [project.configurations[serverConf]]
 
             // For servlet 3 support
-            sources.compileClasspath += project.configurations[jetty8Conf]
-            testSources.compileClasspath += project.configurations[jetty8Conf]
-            testSources.runtimeClasspath += project.configurations[jetty8Conf]
+            sources.compileClasspath += [project.configurations[jetty8Conf]]
+            testSources.compileClasspath += [project.configurations[jetty8Conf]]
+            testSources.runtimeClasspath += [project.configurations[jetty8Conf]]
 
             // Add server libs to war
             project.war.classpath(project.configurations[serverConf])
@@ -260,9 +260,9 @@ class DependencyListener implements ProjectEvaluationListener {
         if (!project.configurations.hasProperty(conf)) {
             project.configurations.create(conf)
 
-            sources.compileClasspath += project.configurations[conf]
-            testSources.compileClasspath += project.configurations[conf]
-            testSources.runtimeClasspath += project.configurations[conf]
+            sources.compileClasspath += [project.configurations[conf]]
+            testSources.compileClasspath += [project.configurations[conf]]
+            testSources.runtimeClasspath += [project.configurations[conf]]
         }
     }
 
@@ -274,8 +274,8 @@ class DependencyListener implements ProjectEvaluationListener {
             project.configurations.create(conf)
             project.dependencies.add(conf, "com.vaadin:vaadin-testbench:${project.vaadin.testbench.version}")
 
-            testSources.compileClasspath += project.configurations[conf]
-            testSources.runtimeClasspath += project.configurations[conf]
+            testSources.compileClasspath += [project.configurations[conf]]
+            testSources.runtimeClasspath += [project.configurations[conf]]
         }
     }
 
@@ -288,9 +288,9 @@ class DependencyListener implements ProjectEvaluationListener {
             project.configurations.create(conf)
             project.dependencies.add(conf, "com.vaadin:vaadin-push:${version}")
 
-            sources.compileClasspath += project.configurations[conf]
-            testSources.compileClasspath += project.configurations[conf]
-            testSources.runtimeClasspath += project.configurations[conf]
+            sources.compileClasspath += [project.configurations[conf]]
+            testSources.compileClasspath += [project.configurations[conf]]
+            testSources.runtimeClasspath += [project.configurations[conf]]
         }
     }
 }

--- a/src/main/groovy/fi/jasoft/plugin/GradleVaadinPlugin.groovy
+++ b/src/main/groovy/fi/jasoft/plugin/GradleVaadinPlugin.groovy
@@ -99,7 +99,7 @@ class GradleVaadinPlugin implements Plugin<Project> {
         project.tasks.compileJava.options.debugOptions.debugLevel = 'source,lines,vars'
 
         // Add sources to test classpath
-        project.sourceSets.test.runtimeClasspath += project.files(project.sourceSets.main.java.srcDirs)
+        project.sourceSets.test.runtimeClasspath += [project.files(project.sourceSets.main.java.srcDirs)]
 
         // War project should build the widgetset and themes
         project.war.dependsOn(CompileWidgetsetTask.NAME)

--- a/src/main/groovy/fi/jasoft/plugin/TaskListener.groovy
+++ b/src/main/groovy/fi/jasoft/plugin/TaskListener.groovy
@@ -108,10 +108,10 @@ public class TaskListener implements TaskExecutionListener {
         if (task.getName() == 'javadoc') {
             task.source = Util.getMainSourceSet(project)
             if (project.configurations.findByName(Configuration.JAVADOC.caption()) != null) {
-                task.classpath += project.configurations[Configuration.JAVADOC.caption()]
+                task.classpath += [project.configurations[Configuration.JAVADOC.caption()]]
             }
             if (project.configurations.findByName(Configuration.SERVER.caption()) != null) {
-                task.classpath += project.configurations[Configuration.SERVER.caption()]
+                task.classpath += [project.configurations[Configuration.SERVER.caption()]]
             }
             task.failOnError = false
             task.options.addStringOption("sourcepath", "")
@@ -211,7 +211,7 @@ public class TaskListener implements TaskExecutionListener {
 
     private void configureEclipseWtpPluginComponent(Task task) {
         def wtp = project.eclipse.wtp
-        wtp.component.plusConfigurations += project.configurations[Configuration.SERVER.caption()]
+        wtp.component.plusConfigurations += [project.configurations[Configuration.SERVER.caption()]]
     }
 
     private void configureEclipseWtpPluginFacet(Task task) {

--- a/src/main/groovy/fi/jasoft/plugin/Util.groovy
+++ b/src/main/groovy/fi/jasoft/plugin/Util.groovy
@@ -52,10 +52,10 @@ class Util {
                     project.sourceSets.main.compileClasspath
 
         Util.getMainSourceSet(project).srcDirs.each {
-            classpath += project.files(it)
+            classpath += [project.files(it)]
         }
         project.sourceSets.main.resources.srcDirs.each {
-            classpath += project.files(it)
+            classpath += [project.files(it)]
         }
         return classpath
     }
@@ -160,7 +160,7 @@ class Util {
                 def themeName = it.getName()
                 def fileNameRegExp = ~/$themeName\.s?css/
                 it.traverse(type: FileType.FILES, nameFilter : fileNameRegExp) {
-                    paths += "/VAADIN/addons/$themeName/"+it.getName()
+                    paths += ["/VAADIN/addons/$themeName/"+it.getName()]
                 }
             }
         }


### PR DESCRIPTION
Gradle 2.0 upgraded Groovy to version 2.3.2.  This newer version of Groovy uses a different syntax for appending an element to a collection.  See the [release notes](http://www.gradle.org/docs/current/release-notes#+=-operator-changes-that-typically-affect-configuration-of-eclipse-and-idea-plugin).

This pull request uses the new Groovy syntax and should fix the error mentioned in johndevs/gradle-vaadin-plugin#113.  All tests are passing.
