### PR TITLE
Allow GWT output directory to be customized

### DIFF
--- a/src/main/groovy/fi/jasoft/plugin/configuration/GWTConfiguration.groovy
+++ b/src/main/groovy/fi/jasoft/plugin/configuration/GWTConfiguration.groovy
@@ -92,4 +92,6 @@ class GWTConfiguration {
      * Should GWT be placed first in the classpath when compiling the widgetset.
      */
     boolean gwtSdkFirstInClasspath = false
+
+    File outputDirectory = null
 }

--- a/src/main/groovy/fi/jasoft/plugin/tasks/CompileWidgetsetTask.groovy
+++ b/src/main/groovy/fi/jasoft/plugin/tasks/CompileWidgetsetTask.groovy
@@ -61,7 +61,7 @@ class CompileWidgetsetTask extends DefaultTask {
                 inputs.file(pathJarTask.archivePath)
             }
 
-            def webAppDir = project.convention.getPlugin(WarPluginConvention).webAppDir
+            def webAppDir = project.vaadin.gwt.outputDirectory ?: project.convention.getPlugin(WarPluginConvention).webAppDir
 
             // Widgetset output directory
             def targetDir = new File(webAppDir.canonicalPath, 'VAADIN/widgetsets')
@@ -79,7 +79,7 @@ class CompileWidgetsetTask extends DefaultTask {
             return;
         }
 
-        File webAppDir = project.convention.getPlugin(WarPluginConvention).webAppDir
+        File webAppDir = project.vaadin.gwt.outputDirectory ?: project.convention.getPlugin(WarPluginConvention).webAppDir
 
         File targetDir = new File(webAppDir.canonicalPath + '/VAADIN/widgetsets')
         targetDir.mkdirs()


### PR DESCRIPTION
I have a need to make the GWT compiler write to a different directory than the standard `src/main/webapp` one. This PR allows the default output directory to be overridden via the GWTConfiguration.