### PR TITLE
fix version number checks for vaadin8

### DIFF
--- a/src/main/groovy/fi/jasoft/plugin/Util.groovy
+++ b/src/main/groovy/fi/jasoft/plugin/Util.groovy
@@ -209,7 +209,8 @@ class Util {
     @Memoized
     static isPushSupported(Project project) {
         VersionNumber version = VersionNumber.parse(getResolvedVaadinVersion(project))
-        version.major >= VAADIN_SEVEN_MAJOR_VERSION && version.minor > 0
+        version.major > VAADIN_SEVEN_MAJOR_VERSION ||
+                (version.major == VAADIN_SEVEN_MAJOR_VERSION && version.minor > 0)
     }
 
     /**
@@ -235,7 +236,8 @@ class Util {
     @Memoized
     static boolean isAddonStylesSupported(Project project) {
         VersionNumber version = VersionNumber.parse(getResolvedVaadinVersion(project))
-        version.minor > 0
+        version.major > VAADIN_SEVEN_MAJOR_VERSION ||
+                (version.major == VAADIN_SEVEN_MAJOR_VERSION && version.minor > 0)
     }
 
     /**
@@ -274,7 +276,8 @@ class Util {
             return true
         }
         VersionNumber version = VersionNumber.parse(getVaadinVersion(project))
-        version.minor > 0
+        version.major > VAADIN_SEVEN_MAJOR_VERSION ||
+                (version.major == VAADIN_SEVEN_MAJOR_VERSION && version.minor > 0)
     }
 
     /**


### PR DESCRIPTION
for the upcoming vaadin8 (8.0.0.beta1 was just released), version checks will have to consider version.major in addition to version.minor

Derived from https://github.com/johndevs/gradle-vaadin-plugin/pull/297 to fix style and merge issues.
