### PR TITLE
Fix codenarc violations

### DIFF
--- a/src/main/groovy/fi/jasoft/plugin/Util.groovy
+++ b/src/main/groovy/fi/jasoft/plugin/Util.groovy
@@ -980,11 +980,12 @@ class Util {
      * @return
      *      true if project can have non-resolvable dependencies
      */
+    @SuppressWarnings("DuplicateNumberLiteral")
     @Memoized
     static boolean hasNonResolvableConfigurations(Project project) {
         VersionNumber gradleVersion = VersionNumber.parse(project.gradle.gradleVersion)
         VersionNumber gradleVersionWithUnresolvableDeps = new VersionNumber(3, 3, 0, null)
-        gradleVersion.compareTo(gradleVersionWithUnresolvableDeps) >= 0;
+        gradleVersion >= gradleVersionWithUnresolvableDeps;
     }
 
     /**


### PR DESCRIPTION
We are looking to upgrade to gradle 3.4 and I believe this is the last road block. Let me know if you'd like something different or if there is something else I can help with. I decided to suppress that warning because codenarc was yelling that there were two 3's near each other.

Do you have a time frame for your next maintenance release? 