### PR TITLE
Fix hardcoded superdevmode code server port

### DIFF
--- a/src/main/groovy/fi/jasoft/plugin/configuration/SuperDevModeConfiguration.groovy
+++ b/src/main/groovy/fi/jasoft/plugin/configuration/SuperDevModeConfiguration.groovy
@@ -34,7 +34,7 @@ class SuperDevModeConfiguration extends ApplicationServerConfiguration {
     /**
      * To what port should development mode bind itself to.
      */
-    int codeServerPort = 9997
+    int codeServerPort = 9876
 
     /**
      * Extra arguments passed to the code server

--- a/src/main/groovy/fi/jasoft/plugin/tasks/SuperDevModeTask.groovy
+++ b/src/main/groovy/fi/jasoft/plugin/tasks/SuperDevModeTask.groovy
@@ -91,7 +91,7 @@ class SuperDevModeTask extends DefaultTask {
         superdevmodeProcess += ['-cp', classpath.asPath]
         superdevmodeProcess += 'com.google.gwt.dev.codeserver.CodeServer'
         superdevmodeProcess += ['-bindAddress', configuration.bindAddress]
-        superdevmodeProcess += ['-port', 9876]
+        superdevmodeProcess += ['-port', configuration.codeServerPort ]
         superdevmodeProcess += ['-workDir', widgetsetsDir.canonicalPath]
         superdevmodeProcess += ['-src', javaDir.canonicalPath]
         superdevmodeProcess += ['-logLevel', configuration.logLevel]


### PR DESCRIPTION
Fix uses `configuration.codeServerPort` in lieu of hardcoded value of `9876`