### PR TITLE
Correctly unpack addon scss files

### DIFF
--- a/src/main/groovy/fi/jasoft/plugin/tasks/CompileThemeTask.groovy
+++ b/src/main/groovy/fi/jasoft/plugin/tasks/CompileThemeTask.groovy
@@ -232,8 +232,9 @@ class CompileThemeTask extends DefaultTask {
      */
     static File unpackThemes(Project project) {
         // Unpack Vaadin and addon themes
-        File unpackedThemesDir = project.file("$project.buildDir/VAADIN/themes")
-        File unpackedAddonsThemesDir = project.file("$project.buildDir/VAADIN/addons")
+        File unpackedVaadinDir = project.file("$project.buildDir/VAADIN")
+        File unpackedThemesDir = project.file("$unpackedVaadinDir/themes")
+        File unpackedAddonsThemesDir = project.file("$unpackedVaadinDir/addons")
         unpackedThemesDir.mkdirs()
         unpackedAddonsThemesDir.mkdirs()
 
@@ -258,13 +259,13 @@ class CompileThemeTask extends DefaultTask {
                                 def mf = jarStream.manifest
                                 def attributes = mf?.mainAttributes
                                 String value = attributes?.getValue(themesAttribute)
-                                def themesValue = attributes?.getValue(bundleName) == 'vaadin-themes'
+                                Boolean themesValue = attributes?.getValue(bundleName) == 'vaadin-themes'
                                 if ( value || themesValue ) {
                                     project.logger.info("Unpacking $file")
                                     project.copy {
                                         includeEmptyDirs = false
                                         from project.zipTree(file)
-                                        into project.file("$project.buildDir/VAADIN")
+                                        into unpackedVaadinDir
                                         include 'VAADIN/themes/**/*.scss', 'VAADIN/addons/**/*.scss'
                                         eachFile { details ->
                                             details.path -= 'VAADIN'

--- a/src/main/groovy/fi/jasoft/plugin/tasks/CompileThemeTask.groovy
+++ b/src/main/groovy/fi/jasoft/plugin/tasks/CompileThemeTask.groovy
@@ -17,7 +17,6 @@ package fi.jasoft.plugin.tasks
 
 import fi.jasoft.plugin.Util
 import fi.jasoft.plugin.configuration.CompileThemeConfiguration
-import fi.jasoft.plugin.configuration.VaadinPluginExtension
 import org.gradle.api.DefaultTask
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
@@ -30,7 +29,6 @@ import org.gradle.tooling.BuildActionFailureException
 import java.nio.file.Paths
 import java.util.jar.Attributes
 import java.util.jar.JarInputStream
-
 /**
  * Compiles the SASS theme into CSS
  *
@@ -233,10 +231,11 @@ class CompileThemeTask extends DefaultTask {
      *      returns the directory where the themes has been unpacked
      */
     static File unpackThemes(Project project) {
-
         // Unpack Vaadin and addon themes
-        File unpackedThemesDir = project.file("$project.buildDir/themes")
+        File unpackedThemesDir = project.file("$project.buildDir/VAADIN/themes")
+        File unpackedAddonsThemesDir = project.file("$project.buildDir/VAADIN/addons")
         unpackedThemesDir.mkdirs()
+        unpackedAddonsThemesDir.mkdirs()
 
         project.logger.info("Unpacking themes to $unpackedThemesDir")
         def themesAttribute = new Attributes.Name('Vaadin-Stylesheets')
@@ -259,16 +258,16 @@ class CompileThemeTask extends DefaultTask {
                                 def mf = jarStream.manifest
                                 def attributes = mf?.mainAttributes
                                 String value = attributes?.getValue(themesAttribute)
-                                String themesValue = attributes?.getValue(bundleName) == 'vaadin-themes'
+                                def themesValue = attributes?.getValue(bundleName) == 'vaadin-themes'
                                 if ( value || themesValue ) {
                                     project.logger.info("Unpacking $file")
                                     project.copy {
                                         includeEmptyDirs = false
                                         from project.zipTree(file)
-                                        into unpackedThemesDir
-                                        include 'VAADIN/themes/**/*'
+                                        into project.file("$project.buildDir/VAADIN")
+                                        include 'VAADIN/themes/**/*.scss', 'VAADIN/addons/**/*.scss'
                                         eachFile { details ->
-                                            details.path -= 'VAADIN/themes/'
+                                            details.path -= 'VAADIN'
                                         }
                                     }
                                 }
@@ -281,7 +280,7 @@ class CompileThemeTask extends DefaultTask {
 
         // Copy project theme into unpacked directory
         project.logger.info "Copying project theme into $unpackedThemesDir"
-        project.copy{
+        project.copy {
             from Util.getThemesDirectory(project)
             into unpackedThemesDir
         }

--- a/src/main/groovy/fi/jasoft/plugin/tasks/CompileThemeTask.groovy
+++ b/src/main/groovy/fi/jasoft/plugin/tasks/CompileThemeTask.groovy
@@ -266,7 +266,7 @@ class CompileThemeTask extends DefaultTask {
                                         includeEmptyDirs = false
                                         from project.zipTree(file)
                                         into unpackedVaadinDir
-                                        include 'VAADIN/themes/**/*.scss', 'VAADIN/addons/**/*.scss'
+                                        include 'VAADIN/themes/**/*', 'VAADIN/addons/**/*'
                                         eachFile { details ->
                                             details.path -= 'VAADIN'
                                         }


### PR DESCRIPTION
When using libsass or compass as a compiler, the scss files of used addons could not be included because they weren't extracted to the temporary directory.

This should fix that issue.