### PR TITLE
Fix double braces typo in vaadin-themes dependency (#530)

### DIFF
--- a/src/main/groovy/com/devsoap/plugin/GradleVaadinPlugin.groovy
+++ b/src/main/groovy/com/devsoap/plugin/GradleVaadinPlugin.groovy
@@ -344,7 +344,7 @@ class GradleVaadinPlugin implements Plugin<Project> {
                 dependencies.add(vaadinServer)
 
                 Dependency vaadinThemes = projectDependencies.create(
-                        "com.vaadin:vaadin-themes:${vaadin.version}}")
+                        "com.vaadin:vaadin-themes:${vaadin.version}")
                 dependencies.add(vaadinThemes)
 
                 Dependency widgetsetCompiled = projectDependencies.create(


### PR DESCRIPTION
Double "}}" gradle try to download " https://oss.sonatype.org/content/repositories/vaadin-snapshots/com/vaadin/vaadin-themes/8.5.2%7D/vaadin-themes-8.5.2%7D.pom"  vaadin-themes-8.5.2}.pom