### PR TITLE
Update JettyServerRunner.java

### DIFF
--- a/src/main/java/com/devsoap/plugin/JettyServerRunner.java
+++ b/src/main/java/com/devsoap/plugin/JettyServerRunner.java
@@ -76,7 +76,7 @@ public class JettyServerRunner {
 
         handler.setContextPath("/");
         handler.setBaseResource(Resource.newResource(webAppDir));
-        handler.setParentLoaderPriority(true);
+        handler.setParentLoaderPriority(false);
 
         handler.setExtraClasspath(String.join(";", classesDirs) + ";" + resourcesDir);
 


### PR DESCRIPTION
Setting ParentLoaderPriority to true seem to cause classes in dependency jar to be loaded by the system class loader and not by the webapp one. Causing conflict error when try to perform reflection operations with web app loaded classes.
If you set it to false (the default), Jetty uses standard webapp classloading priority.