### PR TITLE
Fix fatal gradle 7 compile error.

### DIFF
--- a/src/main/groovy/com/devsoap/plugin/tasks/CompileWidgetsetTask.groovy
+++ b/src/main/groovy/com/devsoap/plugin/tasks/CompileWidgetsetTask.groovy
@@ -225,7 +225,7 @@ class CompileWidgetsetTask extends DefaultTask {
             /* Monitor changes in dependencies since upgrading a
             * dependency should also trigger a recompile of the widgetset
             */
-            inputs.files(project.configurations.compile)
+            inputs.files(project.configurations.implementation)
             inputs.files(project.configurations[GradleVaadinPlugin.CONFIGURATION_CLIENT])
             inputs.files(project.configurations[GradleVaadinPlugin.CONFIGURATION_CLIENT_COMPILE])
 


### PR DESCRIPTION
Fixes:
```java
Caused by: groovy.lang.MissingPropertyException: Could not get unknown property 'compile' for configuration container of type org.gradle.api.internal.artifacts.configurations.DefaultConfigurationContainer.
        at org.gradle.internal.metaobject.AbstractDynamicObject.getMissingProperty(AbstractDynamicObject.java:85)
        at org.gradle.internal.metaobject.AbstractDynamicObject.getProperty(AbstractDynamicObject.java:62)
        at org.gradle.api.internal.artifacts.configurations.DefaultConfigurationContainer_Decorated.getProperty(Unknown Source)
        at com.devsoap.plugin.tasks.CompileWidgetsetTask$_closure4.doCall(CompileWidgetsetTask.groovy:228)
```
This issue appears to prevent the plugin from being used with gradle 7 which appears will be required for java 16 support.